### PR TITLE
feat(docs): show current progress status, autoupdated

### DIFF
--- a/.github/workflows/update-badges.yml
+++ b/.github/workflows/update-badges.yml
@@ -1,0 +1,36 @@
+name: Update AoC Badges
+on:
+  schedule:                                      # run workflow based on schedule
+    - cron: '0 6 1-25 12 *'                      # from the 1. December till 25. December every day at 6am
+
+  workflow_dispatch:                             # allow to manually start the workflow
+
+# push:                                          # (disabled) run on push, be carefull with this setting
+                                                 # as the workflow should only be triggered at a rate lower than
+                                                 # 4 times a houre to keep traffic on aoc site low
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v2                # clones your repo, make sure the ssh secret is set!
+        with:
+          ssh-key: ${{ secrets.SSH_KEY }}
+
+      - uses: joblo2213/aoc-badges-action@v2.1
+        with:
+          userid: ${{ secrets.AOC_BOARD_ID }}    # your user id, see setup on how to obtain
+          session: ${{ secrets.AOC_SESSION }}    # secret containing session code, see setup on how to obtain
+
+#         Optional inputs:
+#
+#         leaderboard: 'https://adventofcode.com/2020/leaderboard/private/view/00000.json'               # The url of the leaderboard from witch the data is fetched. Typically your private leaderboard.
+#         file: 'README.md'                                                                              # The file that contains the badges
+#         dayRegex: '(?<=https:\/\/img\.shields\.io\/badge\/day%20📅-)[0-9]+(?=-blue)'                   # Regular expression that finds the content of the day badge iun your file.
+#         starsRegex: '(?<=https:\/\/img\.shields\.io\/badge\/stars%20⭐-)[0-9]+(?=-yellow)'             # Regular expression that finds the content of the stars badge iun your file.
+#         daysCompletedRegex: '(?<=https:\/\/img\.shields\.io\/badge\/days%20completed-)[0-9]+(?=-red)'  # Regular expression that finds the content of the days completed badge iun your file.
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        name: Push changes                       # Step that pushes these local changes back to your github repo
+        commit_message: "docs: Update badges [skip ci]"
+        file_pattern: README.md

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 [![Build Status](https://github.com/amclin/advent-of-code/actions/workflows/release.yml/badge.svg)](https://github.com/amclin/advent-of-code/actions/workflows/release.yml)
 [![codecov](https://codecov.io/gh/amclin/advent-of-code/branch/master/graph/badge.svg)](https://codecov.io/gh/amclin/advent-of-code)
 
+## Status
+
+### 2020
+![](https://img.shields.io/badge/day%20📅-6-blue)
+![](https://img.shields.io/badge/stars%20⭐-12-yellow)
+![](https://img.shields.io/badge/days%20completed-6-red)
+
 ## Start a boilerplate for a new day
 `npm run new`
 ### Special Instructions


### PR DESCRIPTION
Add badges showing the 2020 progress. Includes a GitHub action to auto-update daily from the the AoC leaderboards