### PR TITLE
fix(ci): use github PATs for automated commits

### DIFF
--- a/.github/workflows/update-badges.yml
+++ b/.github/workflows/update-badges.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2                # clones your repo, make sure the ssh secret is set!
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
 
       - uses: joblo2213/aoc-badges-action@v2.1
         with:
@@ -35,5 +35,4 @@ jobs:
         name: Push changes                       # Step that pushes these local changes back to your github repo
         with:
           commit_message: 'docs: Update badges [skip ci]'
-          push_options: '--force'
           file_pattern: README.md


### PR DESCRIPTION
When using PATs, protected branch steps can be bypassed